### PR TITLE
Fix for issue #29

### DIFF
--- a/src/Our.Shield.Core/Operation/UmbracoServiceBase.cs
+++ b/src/Our.Shield.Core/Operation/UmbracoServiceBase.cs
@@ -46,14 +46,16 @@ namespace Our.Shield.Core.Operation
 
         private IPublishedContent GetPublished<T>(int id)
         {
-            switch (typeof(T))
-            {
-                case IPublishedMediaCache _:
-                    return UmbContext.MediaCache.GetById(id);
-                case IPublishedContentCache _:
-                    return UmbContext.ContentCache.GetById(id);
-            }
-            return null;
+            if (typeof(T) == typeof(IPublishedMediaCache))
+			{
+				return UmbContext.MediaCache.GetById(id);
+			}
+			if (typeof(T) == typeof(IPublishedContentCache))
+			{
+				return UmbContext.ContentCache.GetById(id);
+			}
+
+			return null;
         }
 
         internal IPublishedContent GetPublished<T>(string cacheKeyId, int id)

--- a/src/Our.Shield.Core/Operation/UmbracoServiceBase.cs
+++ b/src/Our.Shield.Core/Operation/UmbracoServiceBase.cs
@@ -68,7 +68,10 @@ namespace Our.Shield.Core.Operation
             }
 
             published = GetPublished<T>(id);
-            SetPublished<T>(cacheKeyId, published);
+            if (published != null)
+	    {
+		SetPublished<T>(cacheKeyId, published);
+	    }
             return published;
         }
 

--- a/src/Our.Shield.MediaProtection/Models/MediaProtectionApp.cs
+++ b/src/Our.Shield.MediaProtection/Models/MediaProtectionApp.cs
@@ -9,8 +9,11 @@ using System.Net;
 using System.Text.RegularExpressions;
 using System.Web;
 using Umbraco.Core;
+using Umbraco.Core.Configuration;
 using Umbraco.Core.Models;
 using Umbraco.Core.Security;
+using Umbraco.Web;
+using Umbraco.Web.Routing;
 
 namespace Our.Shield.MediaProtection.Models
 {
@@ -134,7 +137,21 @@ namespace Our.Shield.MediaProtection.Models
                    
                 var secureMedia = ApplicationContext.Current.ApplicationCache.RuntimeCache.GetCacheItem(CacheKey + "F" + filename, () =>
                 {
-                    var mediaService = new UmbracoMediaService(Umbraco.Web.UmbracoContext.Current);
+                    var umbracoContext = Umbraco.Web.UmbracoContext.Current;
+
+					if (umbracoContext == null)
+					{
+						var newHttpContext = new HttpContextWrapper(HttpContext.Current);
+						umbracoContext = UmbracoContext.EnsureContext(
+							newHttpContext,
+							ApplicationContext.Current,
+							new Umbraco.Web.Security.WebSecurity(newHttpContext, ApplicationContext.Current),
+							UmbracoConfig.For.UmbracoSettings(),
+							UrlProviderResolver.Current.Providers,
+							true);
+					}
+
+					var mediaService = new UmbracoMediaService(umbracoContext);
                     var mediaId = mediaService.Id(filename);
 
                     if (mediaId == null)


### PR DESCRIPTION
This fixes the problems I wrote about in issue 29, that there is sometimes a null reference exception because the umbraco context was null. Now I check if it is null, and if it is, I create it before passing it in to the UmbracoMediaService.
I also had to make two other very minor changes, the type was not matching in the switch statement and was returning null, so I rewrote it to be two if statements, then it worked for me. 
Also I needed to add a null check before calling the SetPublished method, sometimes the code was trying to publish something but published was null, so there was a null reference exception. This is now checked.